### PR TITLE
feat: command to display server icon.

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,11 +1,10 @@
-import os
 from datetime import datetime
 
 from disnake import AllowedMentions, Intents
 from disnake.ext import commands
 from loguru import logger
 
-from bot.utils.extensions import EXTENSIONS, walk_extensions
+from bot.utils.extensions import EXTENSIONS
 
 from . import constants
 
@@ -46,7 +45,7 @@ class Bot(commands.Bot):
             except Exception as e:
                 logger.error(f"Error when loading extension: {ext}\n{e}")
 
-        logger.info("Finished loading extenisons")
+        logger.info("Finished loading extensions")
 
     def run(self) -> None:
         """Run the bot with the token in constants.py/.env ."""


### PR DESCRIPTION
Closes #3 .

The user facing messages will probably need to be polished.

When `guild_id` is provided:
<img width="458" alt="2022-01-30_16-12" src="https://user-images.githubusercontent.com/37447267/151696794-887e6bd3-7019-461d-846f-7a76c93f9b96.png">
When the ID is invalid or the server does not have an icon:
<img width="328" alt="2022-01-30_16-12_1" src="https://user-images.githubusercontent.com/37447267/151696798-6fa725e8-557f-4f79-aa29-47f10a731a41.png">
When `invite` is provided:
<img width="355" alt="2022-01-30_16-13" src="https://user-images.githubusercontent.com/37447267/151696789-1c20f926-95cb-4330-a51f-21c928cf512b.png">

Defaults to the current server if no arguments are given and raises `BadArgument` if an invite to a group DM is provided.