### PR TITLE
feat: use attachment options for attachments

### DIFF
--- a/bot/exts/conversions/convert.py
+++ b/bot/exts/conversions/convert.py
@@ -22,27 +22,64 @@ class Convert(commands.Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
+    async def do_conversion(
+        self,
+        inter: ApplicationCommandInteraction,
+        url: str,
+        output_format: OutputFormats,
+    ) -> None:
+        await inter.response.defer()
+        try:
+            image = await download_image(url)
+        except commands.BadArgument as e:
+            try:  # It might be a .SVG
+                raw_bytes = (await download_bytes(url)).getvalue()
+                image = await in_executor(rasterize_svg, raw_bytes)
+            except BadArgument:
+                raise e  # Raise the original error
+
+        output_file = await image_to_file(image, filename_from_url(url), output_format)
+        await inter.edit_original_message(file=output_file)
+
     @commands.slash_command()
     async def convert(
+        self,
+        inter: ApplicationCommandInteraction,
+    ) -> None:
+        """Converts an image to a given format."""
+        pass
+
+    @convert.sub_command()
+    async def from_url(
+        self,
+        inter: ApplicationCommandInteraction,
+        image_url: str,
+        output_format: OutputFormats,
+    ) -> None:
+        """Converts an image to a given format.
+
+        Parameters
+        ----------
+        image_url: A url to an image to convert.
+        output_format: The requested output format.
+        """
+        await self.do_conversion(inter, image_url, output_format)
+
+    @convert.sub_command()
+    async def from_file(
         self,
         inter: ApplicationCommandInteraction,
         image: Attachment,
         output_format: OutputFormats,
     ) -> None:
-        """Converts an image to a given format."""
-        try:
-            image = await download_image(image.url)
-        except commands.BadArgument as e:
-            try:  # It might be a .SVG
-                raw_bytes = (await download_bytes(image.url)).getvalue()
-                image = await in_executor(rasterize_svg, raw_bytes)
-            except BadArgument:
-                raise e  # Raise the original error
+        """Converts the provided image to a given format.
 
-        output_file = await image_to_file(
-            image, filename_from_url(image.filename), output_format
-        )
-        await inter.response.send_message(file=output_file)
+        Parameters
+        ----------
+        image_url: A url to an image to convert.
+        output_format: The requested output format.
+        """
+        await self.do_conversion(inter, image.url, output_format)
 
 
 def setup(bot: Bot) -> None:

--- a/bot/exts/conversions/convert.py
+++ b/bot/exts/conversions/convert.py
@@ -1,4 +1,7 @@
-from disnake.ext.commands.errors import BadArgument
+from disnake import ApplicationCommandInteraction, Attachment
+from disnake.ext import commands
+from disnake.ext.commands import BadArgument
+
 from bot.bot import Bot
 from bot.constants import OUTPUT_IMAGE_FORMATS
 from bot.utils.executor import in_executor
@@ -9,8 +12,6 @@ from bot.utils.images import (
     image_to_file,
     rasterize_svg,
 )
-from disnake import ApplicationCommandInteraction
-from disnake.ext import commands
 
 OutputFormats = commands.option_enum(OUTPUT_IMAGE_FORMATS)
 
@@ -25,20 +26,22 @@ class Convert(commands.Cog):
     async def convert(
         self,
         inter: ApplicationCommandInteraction,
-        image_url: str,
+        image: Attachment,
         output_format: OutputFormats,
     ) -> None:
         """Converts an image to a given format."""
         try:
-            image = await download_image(image_url)
+            image = await download_image(image.url)
         except commands.BadArgument as e:
             try:  # It might be a .SVG
-                raw_bytes = (await download_bytes(image_url)).getvalue()
-                image = await in_executor(rasterize_svg,raw_bytes)
+                raw_bytes = (await download_bytes(image.url)).getvalue()
+                image = await in_executor(rasterize_svg, raw_bytes)
             except BadArgument:
                 raise e  # Raise the original error
 
-        output_file = await image_to_file(image, filename_from_url(image_url), output_format)
+        output_file = await image_to_file(
+            image, filename_from_url(image.filename), output_format
+        )
         await inter.response.send_message(file=output_file)
 
 

--- a/bot/exts/conversions/rasterize.py
+++ b/bot/exts/conversions/rasterize.py
@@ -20,6 +20,24 @@ class Rasterize(commands.Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
+    async def do_rasterize(
+        self,
+        inter: ApplicationCommandInteraction,
+        image_url: str,
+        output_format: OutputFormats,
+        scale: int,
+    ):
+        await inter.response.defer()
+
+        raw_bytes = (await download_bytes(image_url)).getvalue()
+
+        image = await in_executor(rasterize_svg, raw_bytes, scale)
+        file = await image_to_file(
+            image, filename_from_url(image.filename), output_format
+        )
+
+        await inter.edit_original_message(file=file)
+
     @commands.slash_command()
     async def rasterize(
         self,
@@ -29,15 +47,43 @@ class Rasterize(commands.Cog):
         scale: int = 1,
     ) -> None:
         """Rasterizes a given SVG-file."""
-        await inter.response.defer()
+        pass
 
-        raw_bytes = await image.read()
-        image = await in_executor(rasterize_svg, raw_bytes, scale)
-        file = await image_to_file(
-            image, filename_from_url(image.filename), output_format
-        )
+    @rasterize.sub_command()
+    async def from_url(
+        self,
+        inter: ApplicationCommandInteraction,
+        image_url: str,
+        output_format: OutputFormats = "PNG",
+        scale: int = 1,
+    ):
+        """Rasterizes a given SVG-file.
 
-        await inter.edit_original_message(file=file)
+        Parameters
+        ----------
+        image: The image to rasterize.
+        output_format: The perferred output format.
+        scale: The factor to scale the image by.
+        """
+        await self.do_rasterize(inter, image_url, output_format, scale)
+
+    @rasterize.sub_command()
+    async def from_file(
+        self,
+        inter: ApplicationCommandInteraction,
+        image: Attachment,
+        output_format: OutputFormats = "PNG",
+        scale: int = 1,
+    ):
+        """Rasterizes a given SVG-file.
+
+        Parameters
+        ----------
+        image: The image to rasterize.
+        output_format: The perferred output format.
+        scale: The factor to scale the image by.
+        """
+        await self.do_rasterize(inter, image.url, output_format, scale)
 
 
 def setup(bot: Bot) -> None:

--- a/bot/exts/conversions/resize.py
+++ b/bot/exts/conversions/resize.py
@@ -1,8 +1,8 @@
-from bot.bot import Bot
-from disnake import ApplicationCommandInteraction
+from disnake import ApplicationCommandInteraction, Attachment
 from disnake.ext import commands
-from bot.utils.executor import in_executor
 
+from bot.bot import Bot
+from bot.utils.executor import in_executor
 from bot.utils.images import download_image, image_to_file
 
 Size = tuple[int, int]
@@ -51,7 +51,7 @@ class Resize(commands.Cog):
     async def resize(
         self,
         inter: ApplicationCommandInteraction,
-        image_url: str,
+        img: Attachment,
         width: int = None,
         height: int = None,
         scale: float = commands.param(default=None, gt=0, le=5.0),
@@ -66,9 +66,9 @@ class Resize(commands.Cog):
         scale: The scale of the new image compared to the old image. 1 is equal to the current image.
         """
         await inter.response.defer()
-        image = await download_image(image_url)
+        image = await download_image(img.url)
         try:
-            size = await in_executor(Resize._new_size,image.size, width, height, scale)
+            size = await in_executor(Resize._new_size, image.size, width, height, scale)
         except ValueError as e:
             raise commands.BadArgument(str(e))
 

--- a/bot/exts/conversions/resize.py
+++ b/bot/exts/conversions/resize.py
@@ -47,11 +47,36 @@ class Resize(commands.Cog):
             f_scale = height / size[1]
         return (int(size[0] * f_scale), int(size[1] * f_scale))  # type: ignore
 
-    @commands.slash_command()
-    async def resize(
+    async def do_resize(
         self,
         inter: ApplicationCommandInteraction,
-        img: Attachment,
+        image_url: str,
+        width: int,
+        height: int,
+        scale: float,
+    ):
+        await inter.response.defer()
+        image = await download_image(image_url)
+        try:
+            size = await in_executor(Resize._new_size, image.size, width, height, scale)
+        except ValueError as e:
+            raise commands.BadArgument(str(e))
+
+        image = image.resize(size)
+        await inter.edit_original_message(file=await image_to_file(image))
+
+    @commands.slash_command()
+    async def resize(self, inter: ApplicationCommandInteraction) -> None:
+        """
+        Resizes an image.
+        """
+        pass
+
+    @resize.sub_command()
+    async def from_url(
+        self,
+        inter: ApplicationCommandInteraction,
+        image_url: str,
         width: int = None,
         height: int = None,
         scale: float = commands.param(default=None, gt=0, le=5.0),
@@ -61,19 +86,33 @@ class Resize(commands.Cog):
 
         Parameters
         ----------
+        image_url: the url of the image to resize.
         width: New width in pixels
         height: New height in pixels
         scale: The scale of the new image compared to the old image. 1 is equal to the current image.
         """
-        await inter.response.defer()
-        image = await download_image(img.url)
-        try:
-            size = await in_executor(Resize._new_size, image.size, width, height, scale)
-        except ValueError as e:
-            raise commands.BadArgument(str(e))
+        await self.do_resize(inter, image_url, width, height, scale)
 
-        image = image.resize(size)
-        await inter.edit_original_message(file=await image_to_file(image))
+    @resize.sub_command()
+    async def from_file(
+        self,
+        inter: ApplicationCommandInteraction,
+        image: Attachment,
+        width: int = None,
+        height: int = None,
+        scale: float = commands.param(default=None, gt=0, le=5.0),
+    ) -> None:
+        """
+        Resizes an image.
+
+        Parameters
+        ----------
+        image: the image to resize
+        width: New width in pixels
+        height: New height in pixels
+        scale: The scale of the new image compared to the old image. 1 is equal to the current image.
+        """
+        await self.do_resize(inter, image.url, width, height, scale)
 
 
 def setup(bot: Bot) -> None:

--- a/bot/exts/previewing/preview.py
+++ b/bot/exts/previewing/preview.py
@@ -31,14 +31,18 @@ class Preview(commands.Cog):
         """Command group for previewing assets."""
         pass
 
-    @preview.sub_command()
+    @preview.sub_command_group()
     async def server_icon(
         self,
         inter: ApplicationCommandInteraction,
-        icon: Attachment,
-        mode: Modes = "Dark",
     ) -> None:
-        """Sends a preview of the given image, in different states."""
+        """Sends a preview of the given icon, in different states."""
+        if icon := inter.filled_options.get("icon"):
+            icon = icon.url
+        elif icon := inter.filled_options.get("icon_url"):
+            pass
+        else:
+            raise RuntimeError("the required option was not provided.")
         icon = (await download_image(icon.url)).resize(ICON_SIZE)
         icon = add_background(icon, Preview.background_color(mode.lower()))  # type: ignore
 
@@ -55,6 +59,40 @@ class Preview(commands.Cog):
         preview = await in_executor(_preview)
 
         await inter.response.send_message(file=await image_to_file(preview))
+
+    @server_icon.sub_command('from_url')
+    async def server_icon_from_url(
+        self,
+        inter: ApplicationCommandInteraction,
+        icon_url: str,
+        mode: Modes = "Dark",
+    ):
+        """
+        Send a preview of the given icon in different states.
+
+        Parameters
+        ----------
+        icon_url: The url of the icon.
+        mode: Whether to show the preview in light or dark mode. (Defaults to dark.)
+        """
+        pass
+
+    @server_icon.sub_command('from_file')
+    async def server_icon_from_file(
+        self,
+        inter: ApplicationCommandInteraction,
+        icon: Attachment,
+        mode: Modes = "Dark",
+    ):
+        """
+        Send a preview of the given icon in different states.
+
+        Parameters
+        ----------
+        icon: The icon to preview.
+        mode: Whether to show the preview in light or dark mode. (Defaults to dark.)
+        """
+        pass
 
 
 def setup(bot: Bot) -> None:

--- a/bot/exts/previewing/preview.py
+++ b/bot/exts/previewing/preview.py
@@ -1,11 +1,12 @@
 from typing import Literal
 
+from disnake import ApplicationCommandInteraction, Attachment
+from disnake.ext import commands
+from PIL import Image
+
 from bot.bot import Bot
 from bot.utils.executor import in_executor
 from bot.utils.images import add_background, download_image, image_to_file
-from disnake.ext import commands
-from disnake import ApplicationCommandInteraction
-from PIL import Image
 
 ICON_TEMPLATES = "bot/assets/templates/server_icon/{mode}.png"
 ICON_POSITIONS = [(12, 42), (94, 42), (176, 42)]
@@ -32,10 +33,13 @@ class Preview(commands.Cog):
 
     @preview.sub_command()
     async def server_icon(
-        self, inter: ApplicationCommandInteraction, file_url: str, mode: Modes = "Dark"
+        self,
+        inter: ApplicationCommandInteraction,
+        icon: Attachment,
+        mode: Modes = "Dark",
     ) -> None:
         """Sends a preview of the given image, in different states."""
-        icon = (await download_image(file_url)).resize(ICON_SIZE)
+        icon = (await download_image(icon.url)).resize(ICON_SIZE)
         icon = add_background(icon, Preview.background_color(mode.lower()))  # type: ignore
 
         def _preview():

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,9 +89,9 @@ python-versions = ">=3.7"
 cffi = ">=1.1.0"
 
 [package.extras]
-doc = ["sphinx", "sphinx-rtd-theme"]
-test = ["pytest-runner", "pytest-cov", "pytest-flake8", "pytest-isort"]
 xcb = ["xcffib (>=0.3.2)"]
+test = ["pytest-isort", "pytest-flake8", "pytest-cov", "pytest-runner"]
+doc = ["sphinx-rtd-theme", "sphinx"]
 
 [[package]]
 name = "cairosvg"
@@ -166,8 +166,8 @@ tinycss2 = "*"
 webencodings = "*"
 
 [package.extras]
-doc = ["sphinx", "sphinx-rtd-theme"]
-test = ["pytest", "pytest-cov", "pytest-flake8", "pytest-isort", "coverage"]
+test = ["coverage", "pytest-isort", "pytest-flake8", "pytest-cov", "pytest"]
+doc = ["sphinx-rtd-theme", "sphinx"]
 
 [[package]]
 name = "defusedxml"
@@ -179,7 +179,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "disnake"
-version = "2.4.0"
+version = "2.4.1"
 description = "A Python wrapper for the Discord API"
 category = "main"
 optional = false
@@ -245,7 +245,7 @@ colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
 win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
 
 [package.extras]
-dev = ["codecov (>=2.0.15)", "colorama (>=0.3.4)", "flake8 (>=3.7.7)", "tox (>=3.9.0)", "tox-travis (>=0.12)", "pytest (>=4.6.2)", "pytest-cov (>=2.7.1)", "Sphinx (>=2.2.1)", "sphinx-autobuild (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "black (>=19.10b0)", "isort (>=5.1.1)"]
+dev = ["isort (>=5.1.1)", "black (>=19.10b0)", "sphinx-rtd-theme (>=0.4.3)", "sphinx-autobuild (>=0.7.1)", "Sphinx (>=2.2.1)", "pytest-cov (>=2.7.1)", "pytest (>=4.6.2)", "tox-travis (>=0.12)", "tox (>=3.9.0)", "flake8 (>=3.7.7)", "colorama (>=0.3.4)", "codecov (>=2.0.15)"]
 
 [[package]]
 name = "multidict"
@@ -330,8 +330,8 @@ python-versions = ">=3.6"
 webencodings = ">=0.4"
 
 [package.extras]
-doc = ["sphinx", "sphinx-rtd-theme"]
-test = ["pytest", "pytest-cov", "pytest-flake8", "pytest-isort", "coverage"]
+test = ["coverage", "pytest-isort", "pytest-flake8", "pytest-cov", "pytest"]
+doc = ["sphinx-rtd-theme", "sphinx"]
 
 [[package]]
 name = "tomli"
@@ -366,7 +366,7 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 
 [[package]]
 name = "yarl"
@@ -383,7 +383,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "8aedbf49801be3650c8a7bcd519a69c8d9f8a01678be820e36119046a0ff382c"
+content-hash = "f73c49602adfa82970dc0c12ab6034abcf597728f351d5449055f9fddf3483e6"
 
 [metadata.files]
 aiohttp = [
@@ -556,8 +556,8 @@ defusedxml = [
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 disnake = [
-    {file = "disnake-2.4.0-py3-none-any.whl", hash = "sha256:390250a55ed8bbcc8c5753a72fb8fff2376a30295476edfebd0d2301855fb919"},
-    {file = "disnake-2.4.0.tar.gz", hash = "sha256:d7a9c83d5cbfcec42441dae1d96744f82c2a22403934db5d8862a8279ca4989c"},
+    {file = "disnake-2.4.1-py3-none-any.whl", hash = "sha256:52f95df19c26355bd7376a0c7316101247c6907cf32ea51126089152f15935bf"},
+    {file = "disnake-2.4.1.tar.gz", hash = "sha256:ba974336d96e349093a4c6948d85cce563602b4434bd65976b2084110885fc20"},
 ]
 emoji = [
     {file = "emoji-1.6.3.tar.gz", hash = "sha256:cc28bdc1010b1c03c241f69c7af1e8715144ef45a273bfadc14dc89319ba26d0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -179,7 +179,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "disnake"
-version = "2.3.2"
+version = "2.4.0"
 description = "A Python wrapper for the Discord API"
 category = "main"
 optional = false
@@ -190,7 +190,7 @@ aiohttp = ">=3.7.0,<3.9.0"
 
 [package.extras]
 discord = ["discord-disnake"]
-docs = ["sphinx (==4.0.2)", "sphinxcontrib-trio (==1.1.2)", "sphinxcontrib-websupport"]
+docs = ["sphinx (>=4.4.0,<4.5.0)", "sphinxcontrib-trio (==1.1.2)", "sphinx-hoverxref (>=1.0.0,<1.1.0)", "sphinx-autobuild (==2021.3.14)"]
 speed = ["orjson (>=3.5.4)", "aiodns (>=1.1)", "brotli", "cchardet"]
 voice = ["PyNaCl (>=1.3.0,<1.5)"]
 
@@ -383,7 +383,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "94891cb610bbfd0eabffd02fe326c8880df02c547736ca187dab56754e58e134"
+content-hash = "8aedbf49801be3650c8a7bcd519a69c8d9f8a01678be820e36119046a0ff382c"
 
 [metadata.files]
 aiohttp = [
@@ -556,8 +556,8 @@ defusedxml = [
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 disnake = [
-    {file = "disnake-2.3.2-py3-none-any.whl", hash = "sha256:bbbfa7a7a1909e37c66bb7d60af5a63532d68a990e0b0569b339fa85db03a364"},
-    {file = "disnake-2.3.2.tar.gz", hash = "sha256:c5e6b849ea4cf2e3d1aba493013a8027a3e17a9b1d99e1eabb3598d94de7eaf0"},
+    {file = "disnake-2.4.0-py3-none-any.whl", hash = "sha256:390250a55ed8bbcc8c5753a72fb8fff2376a30295476edfebd0d2301855fb919"},
+    {file = "disnake-2.4.0.tar.gz", hash = "sha256:d7a9c83d5cbfcec42441dae1d96744f82c2a22403934db5d8862a8279ca4989c"},
 ]
 emoji = [
     {file = "emoji-1.6.3.tar.gz", hash = "sha256:cc28bdc1010b1c03c241f69c7af1e8715144ef45a273bfadc14dc89319ba26d0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-disnake = "^2.3.0"
+disnake = "^2.4.0"
 loguru = "^0.5.3"
 python-dotenv = "^0.19.2"
 humanize = "^3.13.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-disnake = "^2.4.0"
+disnake = "~=2.4.1"
 loguru = "^0.5.3"
 python-dotenv = "^0.19.2"
 humanize = "^3.13.1"


### PR DESCRIPTION
Discord recently added support for inline attachment uploading to slash commands.

This pr implements using inline attachment uploading for all necessary inputs.
