### PR TITLE
enhance: make `user` argument optional for avatar command

### DIFF
--- a/bot/exts/discord/discord.py
+++ b/bot/exts/discord/discord.py
@@ -25,8 +25,12 @@ class Discord(commands.Cog):
         """Command group for Discord-related utilities."""
 
     @discord.sub_command()
-    async def avatar(self, inter: ApplicationCommandInteraction, user: User) -> None:
+    async def avatar(
+        self, inter: ApplicationCommandInteraction, user: Optional[User] = None
+    ) -> None:
         """Get the avatar of a Discord user."""
+        if user is None:
+            user = inter.author
         embed = create_embed(
             title="Discord avatar",
             description=f"Showing {user.mention}'s avatar.",


### PR DESCRIPTION
If `user` is not provided when invoking the avatar command, it defaults to the author.