### PR TITLE
Bot info: make the user count accurate

### DIFF
--- a/bot/exts/utils/bot_info.py
+++ b/bot/exts/utils/bot_info.py
@@ -45,6 +45,10 @@ class BotInfo(commands.Cog):
         embed.add_field(name="Servers", value=len(guilds))
         embed.add_field(
             name="Members",
+            value=sum([guild.member_count for guild in guilds]),
+        )
+        embed.add_field(
+            name="Unique Members",
             value=len(
                 set().union(set(user.id for user in guild.members) for guild in guilds)
             )  # Length of the union of every single UID

--- a/bot/exts/utils/bot_info.py
+++ b/bot/exts/utils/bot_info.py
@@ -48,7 +48,6 @@ class BotInfo(commands.Cog):
             value=len(
                 set().union(set(user.id for user in guild.members) for guild in guilds)
             )  # Length of the union of every single UID
-            - 1,  # Remove the bot itself
         )
 
         await inter.response.send_message(embed=embed)

--- a/bot/exts/utils/bot_info.py
+++ b/bot/exts/utils/bot_info.py
@@ -45,7 +45,10 @@ class BotInfo(commands.Cog):
         embed.add_field(name="Servers", value=len(guilds))
         embed.add_field(
             name="Members",
-            value=sum([guild.member_count for guild in guilds]),
+            value=len(
+                set().union(set(user.id for user in guild.members) for guild in guilds)
+            )  # Length of the union of every single UID
+            - 1,  # Remove the bot itself
         )
 
         await inter.response.send_message(embed=embed)


### PR DESCRIPTION
This makes the bot count individual users, instead of blindly summing them all. The `- 1` is because of the bot.